### PR TITLE
[RFC] Don't enforce `self` type in `equals` method

### DIFF
--- a/Uuid.php
+++ b/Uuid.php
@@ -85,9 +85,17 @@ class Uuid implements \JsonSerializable
         return uuid_is_null($this->uuid);
     }
 
-    public function equals(self $other): bool
+    public function equals($other): bool
     {
-        return 0 === uuid_compare($this->uuid, $other->uuid);
+        if ($other instance self) {
+            return 0 === uuid_compare($this->uuid, $other->uuid);
+        }
+        
+        if (is_string($other)) {
+            return 0 === uuid_compare($this->uuid, $other);
+        }
+
+        return false;
     }
 
     public function compare(self $other): int


### PR DESCRIPTION
Thanks @lyrixx for the component,

I suggest not to enforce the typehint for the `equals` method to enable more flexibility.

This would allow one to do write code as is:

```
$uuid->equals($anObjectOfAnotherType); // false
$uuid->equals($anotherUuidObject); // true / false
$uuid->equals($aNullValue); // false
$uuid->equals('974d05ab-835e-4d58-af3d-88a0666c5e74'); // true / false
```

What do you think?

PS: I'll update unit tests if a consensus agrees on this change.